### PR TITLE
Removed - from petc-clinic. Added Skaffold support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ target/
 # Branch switching
 generated/
 .DS_Store
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can now access your application by querying the route for the `api-gateway`:
 
 ```
 ✗ cf apps
-Getting apps in org pivot-odedia / space pet-clinic as user@email.com...
+Getting apps in org pivot-odedia / space petclinic as user@email.com...
 OK
 
 name                requested state   instances   memory   disk   urls
@@ -149,7 +149,7 @@ Make sure you're targeting your Kubernetes cluster
 
 ### Setting things up in Kubernetes
 
-Create the namespace for Spring Pet-clinic:
+Create the namespace for Spring petclinic:
 
 ```
 kubectl apply -f k8s/init-namespace/ 
@@ -158,7 +158,7 @@ kubectl apply -f k8s/init-namespace/
 Create a Kubernetes secret to store the URL and API Token of Wavefront (replace values with your own real ones):
 
 ```
-kubectl create secret generic wavefront -n spring-pet-clinic --from-literal=wavefront-url=https://wavefront.surf --from-literal=wavefront-api-token=2e41f7cf-1111-2222-3333-7397a56113ca
+kubectl create secret generic wavefront -n spring-petclinic --from-literal=wavefront-url=https://wavefront.surf --from-literal=wavefront-api-token=2e41f7cf-1111-2222-3333-7397a56113ca
 ```
 
 Create the Wavefront proxy pod, and the various Kubernetes services that will be used later on by our deployments:
@@ -170,7 +170,7 @@ kubectl apply -f k8s/init-services
 Verify the services are available:
 
 ```
-✗ kubectl get svc -n spring-pet-clinic
+✗ kubectl get svc -n spring-petclinic
 NAME                TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
 api-gateway         LoadBalancer   10.7.250.24    <pending>     80:32675/TCP        36s
 customers-service   ClusterIP      10.7.245.64    <none>        8080/TCP            36s
@@ -182,7 +182,7 @@ wavefront-proxy     ClusterIP      10.7.253.85    <none>        2878/TCP,9411/TC
 Verify the wavefront proxy is running:
 
 ```
-✗ kubectl get pods -n spring-pet-clinic
+✗ kubectl get pods -n spring-petclinic
 NAME                              READY   STATUS    RESTARTS   AGE
 wavefront-proxy-dfbd4b695-fdd6t   1/1     Running   0          36s
 
@@ -206,9 +206,9 @@ Deploy the databases:
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm install vets-db-mysql bitnami/mysql --namespace spring-pet-clinic --version 6.14.3
-helm install visits-db-mysql bitnami/mysql --namespace spring-pet-clinic  --version 6.14.3
-helm install customers-db-mysql bitnami/mysql --namespace spring-pet-clinic  --version 6.14.3
+helm install vets-db-mysql bitnami/mysql --namespace spring-petclinic --version 6.14.3
+helm install visits-db-mysql bitnami/mysql --namespace spring-petclinic  --version 6.14.3
+helm install customers-db-mysql bitnami/mysql --namespace spring-petclinic  --version 6.14.3
 ```
 
 ### Deploying the application
@@ -236,7 +236,7 @@ REPOSITORY_PREFIX=harbor.myregistry.com\\/demo ./scripts/deployToKubernetes.sh
 Verify the pods are deployed:
 
 ```bash
-✗ kubectl get pods -n spring-pet-clinic 
+✗ kubectl get pods -n spring-petclinic 
 NAME                                 READY   STATUS    RESTARTS   AGE
 api-gateway-585fff448f-q45jc         1/1     Running   0          4m20s
 customers-db-mysql-master-0          1/1     Running   0          11m
@@ -254,7 +254,7 @@ wavefront-proxy-dfbd4b695-fdd6t      1/1     Running   0          14m
 Get the `EXTERNAL-IP` of the API Gateway:
 
 ```
-✗ kubectl get svc -n spring-pet-clinic api-gateway 
+✗ kubectl get svc -n spring-petclinic api-gateway 
 NAME          TYPE           CLUSTER-IP    EXTERNAL-IP      PORT(S)        AGE
 api-gateway   LoadBalancer   10.7.250.24   34.1.2.22   80:32675/TCP   18m
 ```

--- a/k8s/api-gateway-deployment.yaml
+++ b/k8s/api-gateway-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: api-gateway
   name: api-gateway
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   replicas: 1
   selector:
@@ -46,7 +46,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: kubernetes
         - name: MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI
-          value: proxy://wavefront-proxy.spring-pet-clinic.svc.cluster.local:2878
+          value: proxy://wavefront-proxy.spring-petclinic.svc.cluster.local:2878
         ports:
         - containerPort: 8080
         resources: {}

--- a/k8s/customers-service-deployment.yaml
+++ b/k8s/customers-service-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: customers-service
   name: customers-service
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   replicas: 1
   selector:
@@ -47,7 +47,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: kubernetes
         - name: SPRING_DATASOURCE_URL
-          value: jdbc:mysql://customers-db-mysql.spring-pet-clinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
+          value: jdbc:mysql://customers-db-mysql.spring-petclinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
         - name: SPRING_DATASOURCE_USERNAME
           value: root
         - name: SPRING_DATASOURCE_PASSWORD
@@ -56,7 +56,7 @@ spec:
                name: customers-db-mysql
                key: mysql-root-password
         - name: MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI
-          value: proxy://wavefront-proxy.spring-pet-clinic.svc.cluster.local:2878
+          value: proxy://wavefront-proxy.spring-petclinic.svc.cluster.local:2878
         ports:
         - containerPort: 8080
         resources: {}

--- a/k8s/helm-values/db-values.yaml
+++ b/k8s/helm-values/db-values.yaml
@@ -1,0 +1,25 @@
+## Cluster domain
+##
+clusterDomain: <DOMAIN>
+
+## Admin (root) credentials
+##
+root:
+  ## MySQL admin password
+  ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-the-root-password-on-first-run
+  ##
+  password: <PASSWORD>
+ 
+## Custom user/db credentials
+##
+db:
+  ## MySQL username and password
+  ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-user-on-first-run
+  ## Note that this user should be different from the MySQL replication user (replication.user)
+  ##
+  user: admin
+  password: <PASSWORD>
+  ## Database to create
+  ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-on-first-run
+  ##
+  name: service_instance_db

--- a/k8s/init-namespace/01-namespace.yaml
+++ b/k8s/init-namespace/01-namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: spring-pet-clinic
+  name: spring-petclinic

--- a/k8s/init-services/02-config-map.yaml
+++ b/k8s/init-services/02-config-map.yaml
@@ -2,8 +2,8 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: pet-clinic-config
-  namespace: spring-pet-clinic
+  name: petclinic-config
+  namespace: spring-petclinic
 data:
   application.yaml: |-
     server:
@@ -18,7 +18,7 @@ data:
 
     wavefront:
       application:
-        name: spring-pet-clinic-k8s
+        name: spring-petclinic-k8s
       freemium-account: true
 
     # Logging
@@ -52,8 +52,8 @@ data:
           wavefront:
             enabled: true
 
-    customers-service-id: http://customers-service.spring-pet-clinic.svc.cluster.local:8080
-    visits-service-id: http://vists-service.spring-pet-clinic.svc.cluster.local:8080
+    customers-service-id: http://customers-service.spring-petclinic.svc.cluster.local:8080
+    visits-service-id: http://vists-service.spring-petclinic.svc.cluster.local:8080
 
     spring:
       datasource:
@@ -94,19 +94,19 @@ data:
             proto-append: false
           routes:
             - id: vets-service
-              uri: http://vets-service.spring-pet-clinic.svc.cluster.local:8080
+              uri: http://vets-service.spring-petclinic.svc.cluster.local:8080
               predicates:
                 - Path=/api/vet/**
               filters:
                 - StripPrefix=2
             - id: visits-service
-              uri: http://visits-service.spring-pet-clinic.svc.cluster.local:8080
+              uri: http://visits-service.spring-petclinic.svc.cluster.local:8080
               predicates:
                 - Path=/api/visit/**
               filters:
                 - StripPrefix=2
             - id: customers-service
-              uri: http://customers-service.spring-pet-clinic.svc.cluster.local:8080
+              uri: http://customers-service.spring-petclinic.svc.cluster.local:8080
               predicates:
                 - Path=/api/customer/**
               filters:

--- a/k8s/init-services/03-role.yaml
+++ b/k8s/init-services/03-role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
   name: namespace-reader
 rules:
   - apiGroups: ["", "extensions", "apps"]
@@ -14,7 +14,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: namespace-reader-binding
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 subjects:
 - kind: ServiceAccount
   name: default

--- a/k8s/init-services/04-wavefront.yaml
+++ b/k8s/init-services/04-wavefront.yaml
@@ -7,7 +7,7 @@ metadata:
     app: wavefront-proxy
     name: wavefront-proxy
   name: wavefront-proxy
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   replicas: 1
   selector:
@@ -35,7 +35,7 @@ spec:
                key: wavefront-api-token
         # Uncomment the below lines to consume Zipkin/Istio traces
         - name: WAVEFRONT_PROXY_ARGS
-          value: --traceZipkinListenerPorts 9411 --traceZipkinApplicationName spring-pet-clinic-k8s
+          value: --traceZipkinListenerPorts 9411 --traceZipkinApplicationName spring-petclinic-k8s
         ports:
         - containerPort: 2878
           protocol: TCP
@@ -51,7 +51,7 @@ metadata:
   name: wavefront-proxy
   labels:
     app: wavefront-proxy
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   ports:
   - name: wavefront

--- a/k8s/init-services/05-api-gateway-service.yaml
+++ b/k8s/init-services/05-api-gateway-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: api-gateway
   name: api-gateway
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   ports:
   - name: "80"

--- a/k8s/init-services/06-customers-service-service.yaml
+++ b/k8s/init-services/06-customers-service-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: customers-service
   name: customers-service
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   ports:
   - name: "8080"

--- a/k8s/init-services/07-vets-service-service.yaml
+++ b/k8s/init-services/07-vets-service-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: vets-service
   name: vets-service
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   ports:
   - name: "8080"

--- a/k8s/init-services/08-visits-service-service.yaml
+++ b/k8s/init-services/08-visits-service-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: visits-service
   name: visits-service
-  namespace: spring-pet-clinic  
+  namespace: spring-petclinic  
 spec:
   ports:
   - name: "8080"

--- a/k8s/vets-service-deployment.yaml
+++ b/k8s/vets-service-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: vets-service
   name: vets-service
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   replicas: 1
   selector:
@@ -47,7 +47,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: kubernetes
         - name: SPRING_DATASOURCE_URL
-          value: jdbc:mysql://vets-db-mysql.spring-pet-clinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
+          value: jdbc:mysql://vets-db-mysql.spring-petclinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
         - name: SPRING_DATASOURCE_USERNAME
           value: root
         - name: SPRING_DATASOURCE_PASSWORD
@@ -56,7 +56,7 @@ spec:
                name: vets-db-mysql
                key: mysql-root-password
         - name: MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI
-          value: proxy://wavefront-proxy.spring-pet-clinic.svc.cluster.local:2878
+          value: proxy://wavefront-proxy.spring-petclinic.svc.cluster.local:2878
         ports:
         - containerPort: 8080
         resources: {}

--- a/k8s/visits-service-deployment.yaml
+++ b/k8s/visits-service-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: visits-service
   name: visits-service
-  namespace: spring-pet-clinic
+  namespace: spring-petclinic
 spec:
   replicas: 1
   selector:
@@ -46,7 +46,7 @@ spec:
         - name: SPRING_PROFILES_ACTIVE
           value: kubernetes
         - name: SPRING_DATASOURCE_URL
-          value: jdbc:mysql://visits-db-mysql.spring-pet-clinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
+          value: jdbc:mysql://visits-db-mysql.spring-petclinic.svc.cluster.local:3306/my_database?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=customers-db
         - name: SPRING_DATASOURCE_USERNAME
           value: root
         - name: SPRING_DATASOURCE_PASSWORD
@@ -55,7 +55,7 @@ spec:
                name: visits-db-mysql
                key: mysql-root-password
         - name: MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI
-          value: proxy://wavefront-proxy.spring-pet-clinic.svc.cluster.local:2878
+          value: proxy://wavefront-proxy.spring-petclinic.svc.cluster.local:2878
         ports:
         - containerPort: 8080
         resources: {}

--- a/scripts/createRegistryCreds.sh
+++ b/scripts/createRegistryCreds.sh
@@ -1,0 +1,3 @@
+# This will create a regcreds file to apply to the spring-petclinic namespace 
+
+kubectl create secret docker-registry regcred -n spring-petclinic --docker-server=<REGISTRY> --docker-username=<USERNAME> --docker-password=<PASSWORD> --docker-email=<EMAIL_ADDRESS> --dry-run=client -o yaml > ./k8s/init-namespace/02-regcreds.yaml

--- a/spring-petclinic-api-gateway/skaffold.yaml
+++ b/spring-petclinic-api-gateway/skaffold.yaml
@@ -1,0 +1,82 @@
+apiVersion: skaffold/v2beta6
+kind: Config
+metadata:
+  name: spring-petclinic-cloud
+build:
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: spring-petclinic-config-server
+    context:  ./spring-petclinic-config-server
+    buildpacks:
+      builder:  gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true
+  - image: spring-petclinic-discovery-server
+    context:  ./spring-petclinic-discovery-server
+    buildpacks:
+      builder:  gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true
+  - image: spring-petclinic-customers-service
+    context:  ./spring-petclinic-customers-service
+    buildpacks:
+      builder:  gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true
+  - image: spring-petclinic-visits-service
+    context:  ./spring-petclinic-visits-service
+    buildpacks:
+      builder: gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true
+  - image: spring-petclinic-vets-service
+    context:  ./spring-petclinic-vets-service
+    buildpacks:
+      builder:  gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true
+  - image: spring-petclinic-api-gateway
+    context:  ./spring-petclinic-api-gateway
+    buildpacks:
+      builder:  gcr.io/paketo-buildpacks/builder:base
+      trustBuilder: true     
+deploy:
+  statusCheckDeadlineSeconds: 240
+  helm:
+    releases:
+    - name: customers-db-mysql
+      chartPath: bitnami/mysql #Change to your local ChartRepo if appropriate -> kubeapps/mysql
+      valuesFiles: 
+        - customers-db-values.yaml
+      namespace: spring-petclinic
+      remote: true
+      wait: true
+    - name: vets-db-mysql
+      chartPath: bitnami/mysql #Change to your local ChartRepo if appropriate -> kubeapps/mysql
+      valuesFiles: 
+        - vets-db-values.yaml
+      namespace: spring-petclinic
+      remote: true
+      wait: true
+    - name: visits-db-mysql
+      chartPath: bitnami/mysql #Change to your local ChartRepo if appropriate -> kubeapps/mysql
+      valuesFiles: 
+        - visits-db-values.yaml
+      namespace: spring-petclinic
+      remote: true
+      wait: true
+    flags:
+      install:
+        - "--create-namespace" 
+  kubectl:
+    manifests:
+    - k8s/init-namespace/01-namespace.yaml
+    - k8s/init-namespace/02-regcreds.yaml
+    - k8s/init-services/02-config-map.yaml
+    - k8s/init-services/03-role.yaml
+    #- k8s/init-services/04-wavefront.yaml
+    - k8s/init-services/05-api-gateway-service.yaml
+    - k8s/init-services/06-customers-service-service.yaml
+    - k8s/init-services/07-vets-service-service.yaml
+    - k8s/init-services/08-visits-service-service.yaml
+    - k8s/api-gateway-deployment.yaml
+    - k8s/customers-service-deployment.yaml
+    - k8s/vets-service-deployment.yaml
+    - k8s/visits-service-deployment.yaml
+  

--- a/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/bootstrap.yml
@@ -28,7 +28,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:

--- a/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-customers-service/src/main/resources/bootstrap.yml
@@ -22,7 +22,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:
@@ -39,7 +39,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:

--- a/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-vets-service/src/main/resources/bootstrap.yml
@@ -22,7 +22,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:
@@ -39,7 +39,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:

--- a/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
+++ b/spring-petclinic-visits-service/src/main/resources/bootstrap.yml
@@ -22,7 +22,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:
@@ -39,7 +39,7 @@ spring:
         enabled: true
       config:
         enabled: true
-        name: pet-clinic-config
+        name: petclinic-config
 management:
   endpoint:
     restart:


### PR DESCRIPTION
Creating this PR almost as more of an FYI....so you can feel free to accept or reject.  
1) Spring-petclinic is the name of the project, so i made that change across the repo.  Makes it more consistent and easier to extend.  The petclinic pet-clinic difference was confusing.
2) Added needed files to support a skaffold deployment including a skaffold.yaml file.  skaffold dev --default-repo <repo> will sping up the mysql instances in K8s and then spin up the app.  THen, any change made to the code will cause a rebuild and repush.   Note:  This skaffold implementation also leverages Cloud Native Buildpacks to build the containers, so it's consistent with a CI/CD pipeline that leverages Build Service or Paketo.