### PR TITLE
Update readme and k8s script to not need to change the repo prefix env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,24 +215,10 @@ helm install customers-db-mysql bitnami/mysql --namespace spring-pet-clinic  --v
 
 ### Deploying the application
 
-Our delpoyment yamls have a placeholder called `REPOSITORY_PREFIX` so we'll be able to deploy the images from any Docker registry. Sadly, Kubernetes doesn't support environment variables in the yaml descriptors. We have a small script to do it for us.
-
-We'll need to update our `REPOSITORY_PREFIX` since we're going to use it with the `sed` command which doesn't like `/` in the strings it replaces. Add a double `\\` after every `/`. For example, instead of this:
+Our deployment YAMLs have a placeholder called `REPOSITORY_PREFIX` so we'll be able to deploy the images from any Docker registry. Sadly, Kubernetes doesn't support environment variables in the YAML descriptors. We have a small script to do it for us and run our deployments:
 
 ```
-REPOSITORY_PREFIX=harbor.myregistry.com/demo
-```
-
-Set the value to this:
-
-```
-REPOSITORY_PREFIX=harbor.myregistry.com\\/demo
-```
-
-Now we can deploy our containers:
-
-```
-REPOSITORY_PREFIX=harbor.myregistry.com\\/demo ./scripts/deployToKubernetes.sh
+./scripts/deployToKubernetes.sh
 ```
 
 Verify the pods are deployed:

--- a/scripts/deployToKubernetes.sh
+++ b/scripts/deployToKubernetes.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-#Make sure you set REPOSITOR_PREFIX with double quote for each path route. For example - my-registry.com\\/demo
-cat ./k8s/*.yaml | \
-sed 's/\${REPOSITORY_PREFIX}'"/${REPOSITORY_PREFIX}/g" | \
-kubectl apply -f -
+if [ -z "${REPOSITORY_PREFIX}" ]
+then 
+    echo "Please set the REPOSITORY_PREFIX"
+else 
+    cat ./k8s/*.yaml | \
+    sed 's#\${REPOSITORY_PREFIX}'"#${REPOSITORY_PREFIX}#g" | \
+    kubectl apply -f -
+fi


### PR DESCRIPTION
Changed the sed to use `#` instead of `/` so `REPOSITORY_PREFIX` doesn't need to be changed to have `\\`
```
sed 's#\${REPOSITORY_PREFIX}'"#${REPOSITORY_PREFIX}#g"
```
Updated the script to check that the env is set (in case they use a different window) and updated the README.