### PR TITLE
Add autoinjection label for use with Istio/Tanzu Service Mesh

### DIFF
--- a/k8s/init-namespace/01-namespace.yaml
+++ b/k8s/init-namespace/01-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: spring-petclinic
+  labels:
+    istio-injection: enabled


### PR DESCRIPTION
Adding the label won't hurt if Istio is not used but enabled sidecar
injection when it is.