### PR TITLE
Request deployment CPU requests

### DIFF
--- a/k8s/api-gateway-deployment.yaml
+++ b/k8s/api-gateway-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           limits:
             memory: 1Gi
           requests:
-            cpu: 2000m
+            cpu: 200m
             memory: 1Gi
         env:
         - name: SPRING_PROFILES_ACTIVE

--- a/k8s/customers-service-deployment.yaml
+++ b/k8s/customers-service-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           limits:
             memory: 1Gi
           requests:
-            cpu: 2000m
+            cpu: 200m
             memory: 1Gi
         env:
         - name: SPRING_PROFILES_ACTIVE

--- a/k8s/vets-service-deployment.yaml
+++ b/k8s/vets-service-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           limits:
             memory: 1Gi
           requests:
-            cpu: 2000m
+            cpu: 200m
             memory: 1Gi
         env:
         - name: SPRING_PROFILES_ACTIVE

--- a/k8s/visits-service-deployment.yaml
+++ b/k8s/visits-service-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           limits:
             memory: 1Gi
           requests:
-            cpu: 2000m
+            cpu: 200m
             memory: 1Gi
         env:
         - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
Change CPU requests from 2000m (2 CPUs) to 200m (20% of a CPU) to avoid
having to deploy large K8s clusters for this demo app